### PR TITLE
Fix next_index default value in Passgen.py

### DIFF
--- a/Passgen.py
+++ b/Passgen.py
@@ -166,7 +166,7 @@ class PasswordManager:
                 indices.append(index)
             except:
                 continue
-        next_index = max(indices, default=0) + 1
+        next_index = max(indices, default=1) + 1
 
         backup_file = BASE_DIR / f"{next_index}-Password_Backup({today}).txt"
 


### PR DESCRIPTION
This will fix the backup index issue where if the date was different, the index of the backup would result back to 0 and have the same number,